### PR TITLE
Use new multi-platform Docker image

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -1,26 +1,24 @@
-FROM --platform=linux/amd64 nfcore/base:2.1
-LABEL \
-    author = "Christophe Avenel" \
-    description = "Temporary Dockerfile for nf-core/spatialtranscriptomics" \
-    maintainer = "christophe.avenel@it.uu.se"
+# First stage: multi-platform Quarto image
+FROM jdutant/quarto-minimal:1.3.313 as quarto
 
-RUN apt-get -y update; apt-get -y install -y --no-install-recommends \
-    pandoc \
-    pandoc-citeproc \
-    curl \
-    gdebi-core \
-    && rm -rf /var/lib/apt/lists/*
+# Second stage: multi-platform Mamba image
+FROM condaforge/mambaforge:23.1.0-1
 
-# Install quarto
-ARG QUARTO_VERSION="1.3.302"
-RUN curl -o quarto-linux-amd64.deb -L https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb
-RUN gdebi --non-interactive quarto-linux-amd64.deb
+# Copy Quarto installation from first stage and add to PATH
+COPY --from=quarto /opt/quarto /opt/quarto
+ENV PATH="${PATH}:/opt/quarto/bin"
 
-# Copy and install the Conda environment
+# Install packages using Mamba; also remove static libraries, python bytecode
+# files and javascript source maps that are not required for execution
 COPY environment.yml ./
-RUN conda install -c conda-forge mamba \
-    && mamba env update --name base --file environment.yml \
-    && mamba clean --all --force-pkgs-dirs --yes
+RUN mamba env update --name base --file environment.yml \
+    && mamba clean --all --force-pkgs-dirs --yes \
+    && find /opt/conda -follow -type f -name '*.a' -delete \
+    && find /opt/conda -follow -type f -name '*.pyc' -delete \
+    && find /opt/conda -follow -type f -name '*.js.map' -delete
 
-# Start Bash shell by default
 CMD /bin/bash
+
+LABEL \
+    authors = "Erik Fasterius, Christophe Avenel" \
+    description = "Dockerfile for nf-core/spatialtranscriptomics report modules"

--- a/env/environment.yml
+++ b/env/environment.yml
@@ -2,19 +2,10 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  # Python packages
-  - bbknn=1.5.1
-  - leidenalg=0.9.1
-  - matplotlib=3.7.1
-  - numpy=1.23.0
-  - scikit-learn=1.2.2
-  - scanorama=1.7.3
-  - scanpy=1.9.3
-  - scipy=1.10.1
-  - seaborn=0.12.2
-  - umap-learn=0.5.3
-  - papermill=2.3.4
   - jupyter=1.0.0
+  - leidenalg=0.9.1
+  - papermill=2.3.4
   - pip=23.0.1
+  - scanpy=1.9.3
   - pip:
       - SpatialDE==1.1.3

--- a/modules/local/st_clustering.nf
+++ b/modules/local/st_clustering.nf
@@ -4,13 +4,12 @@
 process ST_CLUSTERING {
 
     // TODO: Add a better description
-    // TODO: Add proper Conda/container directive
-    // TODO: Export versions
+    // TODO: Find solution for Quarto with Conda
 
     tag "${meta.id}"
     label "process_low"
 
-    container "cavenel/spatialtranscriptomics"
+    container "erikfas/spatialtranscriptomics"
 
     input:
     path(report)

--- a/modules/local/st_clustering.nf
+++ b/modules/local/st_clustering.nf
@@ -19,7 +19,7 @@ process ST_CLUSTERING {
     tuple val(meta), path("st_adata_processed.h5ad"), emit: st_adata_processed
     tuple val(meta), path("st_clustering.html")     , emit: html
     tuple val(meta), path("st_clustering_files")    , emit: html_files
-    // path("versions.yml")                              , emit: versions
+    path("versions.yml")                            , emit: versions
 
     script:
     """
@@ -28,5 +28,11 @@ process ST_CLUSTERING {
         -P fileNameST:${st_adata_norm} \
         -P resolution:${params.st_cluster_resolution} \
         -P saveFileST:st_adata_processed.h5ad
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        quarto: \$(quarto -v)
+        scanpy: \$(python -c "import scanpy; print(scanpy.__version__)")
+    END_VERSIONS
     """
 }

--- a/modules/local/st_qc_and_normalisation.nf
+++ b/modules/local/st_qc_and_normalisation.nf
@@ -21,7 +21,7 @@ process ST_QC_AND_NORMALISATION {
     tuple val(meta), path("st_adata_plain.h5ad")          , emit: st_data_plain
     tuple val(meta), path("st_qc_and_normalisation.html") , emit: html
     tuple val(meta), path("st_qc_and_normalisation_files"), emit: html_files
-    // path("versions.yml")                                    , emit: versions
+    path("versions.yml")                                  , emit: versions
 
     script:
     """
@@ -38,5 +38,11 @@ process ST_QC_AND_NORMALISATION {
         -P histplotQCbins:${params.st_preprocess_hist_qc_bins} \
         -P nameDataPlain:st_adata_plain.h5ad \
         -P nameDataNorm:st_adata_norm.h5ad
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        quarto: \$(quarto -v)
+        scanpy: \$(python -c "import scanpy; print(scanpy.__version__)")
+    END_VERSIONS
     """
 }

--- a/modules/local/st_qc_and_normalisation.nf
+++ b/modules/local/st_qc_and_normalisation.nf
@@ -3,13 +3,13 @@
 //
 process ST_QC_AND_NORMALISATION {
 
-    // TODO: Add final Conda/container directive
-    // TODO: Export versions
+    // TODO: Add a better description
+    // TODO: Find solution for Quarto with Conda
 
     tag "${meta.id}"
     label "process_low"
 
-    container "cavenel/spatialtranscriptomics"
+    container "erikfas/spatialtranscriptomics"
 
     input:
     path(report)

--- a/modules/local/st_spatial_de.nf
+++ b/modules/local/st_spatial_de.nf
@@ -3,13 +3,13 @@
 //
 process ST_SPATIAL_DE {
 
-    // TODO: Add proper Conda/container directive
-    // TODO: Export versions
+    // TODO: Add a better description
+    // TODO: Find solution for Quarto with Conda
 
     tag "${meta.id}"
     label "process_medium"
 
-    container "cavenel/spatialtranscriptomics"
+    container "erikfas/spatialtranscriptomics"
 
     input:
     path(report)

--- a/modules/local/st_spatial_de.nf
+++ b/modules/local/st_spatial_de.nf
@@ -19,7 +19,7 @@ process ST_SPATIAL_DE {
     tuple val(meta), path("*.csv")              , emit: degs
     tuple val(meta), path("st_spatial_de.html") , emit: html
     tuple val(meta), path("st_spatial_de_files"), emit: html_files
-    // path("versions.yml")                          , emit: versions
+    path("versions.yml")                        , emit: versions
 
     script:
     """
@@ -29,5 +29,13 @@ process ST_SPATIAL_DE {
         -P numberOfColumns:${params.st_spatial_de_ncols} \
         -P saveDEFileName:st_gde.csv \
         -P saveSpatialDEFileName:st_spatial_de.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        quarto: \$(quarto -v)
+        leidenalg: \$(python -c "import leidenalg; print(leidenalg.__version__)")
+        scanpy: \$(python -c "import scanpy; print(scanpy.__version__)")
+        SpatialDE: \$(python -c "import SpatialDE; print(SpatialDE.__version__)")
+    END_VERSIONS
     """
 }

--- a/subworkflows/local/st_postprocess.nf
+++ b/subworkflows/local/st_postprocess.nf
@@ -27,6 +27,7 @@ workflow ST_POSTPROCESS {
         report_clustering,
         st_adata_norm
     )
+    ch_versions = ch_versions.mix(ST_CLUSTERING.out.versions)
 
     //
     // Spatial differential expression
@@ -35,6 +36,7 @@ workflow ST_POSTPROCESS {
         report_spatial_de,
         ST_CLUSTERING.out.st_adata_processed
     )
+    ch_versions = ch_versions.mix(ST_SPATIAL_DE.out.versions)
 
     emit:
     spatial_degs    = ST_SPATIAL_DE.out.degs    // channel: [ val(sample), csv ]

--- a/subworkflows/local/st_preprocess.nf
+++ b/subworkflows/local/st_preprocess.nf
@@ -27,7 +27,7 @@ workflow ST_PREPROCESS {
         st_raw,
         mito_data
     )
-    // ch_versions = ch_versions.mix(ST_QC_AND_NORMALISATION.out.versions)
+    ch_versions = ch_versions.mix(ST_QC_AND_NORMALISATION.out.versions)
 
     emit:
     st_data_norm  = ST_QC_AND_NORMALISATION.out.st_data_norm  // channel: [ val(sample), h5ad ]


### PR DESCRIPTION
This PR contains a new multi-platform Docker image that works on both AMD64 and ARM64. It is a multi-stage image originating from `jdutant/quarto-minimal` (a minimal ubuntu-based installation of Quarto without pandoc, so only works for HTML reports) and `condaforge/mambaforge` (with Conda and Mamba installed). The image is also optimised in terms of size - compare the old size of 3.37 GB versus the new 1.33 GB.

The image is used for all three Quarto reports, _i.e._ modules `ST_QC_AND_NORMALISATION`, `ST_CLUSTERING` and `ST_SPATIAL_DE`, even though the first two requires a less complicated environment; they do not require `SpatialDE` and `leidenalg` used by the last one. The difference in image size is just 10 MB, though, so I thought it better that all three modules use the same image, so that the user would get just one 1.33 GB image instead of 1.32 + 1.33 GB, even if that could be argue to be more conceptually beautiful.

One problem that remains is that we can't really use a `conda` directive for the report modules, given that they need Quarto. We'll have to think about it.

I also looked into using mulled containers for this (https://github.com/BioContainers/multi-package-containers), but they do not seem to build multi-platform images as far as I can tell. If they change that in the future (or if I've missed something) we should be able to use `jdutant/quarto-minimal` (or an equivalent) as a base and build a mulled container from that, removing the need to keep a `Dockerfile` and an `environment.yml` in the repo. This would, however, not work for `SpatialDE`, as it is not installable directly using Conda (we have to use `pip` from within Conda); mulled containers only work for packages part of Bioconda.