### PR TITLE
Swap X and Y coords

### DIFF
--- a/bin/read_st_data.py
+++ b/bin/read_st_data.py
@@ -103,7 +103,7 @@ def read_visium_mtx(
         # Read coordinates
         positions = pd.read_csv(files["tissue_positions_file"], index_col="barcode", dtype={"in_tissue": bool})
         adata.obs = adata.obs.join(positions, how="left")
-        adata.obsm["spatial"] = adata.obs[["pxl_row_in_fullres", "pxl_col_in_fullres"]].to_numpy()
+        adata.obsm["spatial"] = adata.obs[["pxl_col_in_fullres", "pxl_row_in_fullres"]].to_numpy()
         adata.obs.drop(
             columns=["pxl_row_in_fullres", "pxl_col_in_fullres"],
             inplace=True,


### PR DESCRIPTION
## Before 
![image](https://github.com/nf-core/spatialtranscriptomics/assets/7051479/b99f4fc6-d152-406c-8bce-f880dbeb3750)

## After
![image](https://github.com/nf-core/spatialtranscriptomics/assets/7051479/444f74bc-f91e-4b81-9686-2e60fe2b3513)

This fixes a regression introduced in #45. The problem was that the original version overrode the column names manually, 
and swapped x and y columns while doing so, see [here](https://github.com/nf-core/spatialtranscriptomics/pull/45/files#diff-4a61883ee21f6a917fca2197bbc29fb1eae48d4ce7b4bffb6c5b0622653c927aL113).

another reason to switch to the IO functions of squidpy/spatialdata instead of this custom code. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/spatialtranscriptomics/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/spatialtranscriptomics _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
