### PR TITLE
Fix 'dir' handling for cloud file systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ compatible with further downstream analyses and/or exploration in _e.g._
 
 ### `Added`
 
+- Fix 'dir' handling for cloud file systems [[#122](https://github.com/nf-core/spatialvi/pull/122)]
 - Follow the new Nextflow strict syntax for local (sub-) workflows [[#115](https://github.com/nf-core/spatialvi/pull/115)]
 - Add ability to use unknown slides for Space Ranger-based analyses [[#99](https://github.com/nf-core/spatialvi/issues/99) and [#109](https://github.com/nf-core/spatialvi/pull/109)]
 - Add subworkflow for merging per-sample SpatialData into one [[#96](https://github.com/nf-core/spatialvi/pull/96)]

--- a/subworkflows/local/input_check/main.nf
+++ b/subworkflows/local/input_check/main.nf
@@ -38,11 +38,9 @@ workflow INPUT_CHECK {
 
     // Combine extracted and directory inputs into one channel
     ch_spaceranger_combined = UNTAR_SPACERANGER_INPUT.out.untar
-        .mix ( ch_spaceranger.dir )
-        .map { meta, dir -> meta + [fastq_dir: dir] }
-
+        .mix ( ch_spaceranger.dir.map { meta, dir -> [meta, file(dir)] } )
     // Create final meta map and check input existance
-    ch_spaceranger_input = ch_spaceranger_combined.view().map { it -> create_channel_spaceranger(it) }
+    ch_spaceranger_input = ch_spaceranger_combined.view().map { meta, dir -> create_channel_spaceranger(meta, dir) }
 
     // Downstream analysis: ----------------------------------------------------
 
@@ -112,13 +110,14 @@ def check_downstream_dir(input, hd_bin_size) {
 }
 
 // Function to get list of [ meta, [ fastq_dir, tissue_hires_image, slide, area ]]
-def create_channel_spaceranger(meta) {
+def create_channel_spaceranger(meta, fastq_dir) {
     meta["id"] = meta.remove("sample")
     println "meta: ${meta}"
     def slide = meta.remove("slide")
     def area = meta.remove("area")
-    def fastq_dir = meta.remove("fastq_dir")
-    def fastq_files = file("${fastq_dir}/${meta['id']}*.fastq.gz")
+    def fastq_files = fastq_dir.listFiles().findAll { file ->
+        file.name.startsWith(meta['id']) && file.name.endsWith('.fastq.gz')
+    }
 
     // Convert a path in `meta` to a file object and return it. If key `k` is
     // not contained in `meta` return an empty list which is recognized as 'no

--- a/subworkflows/local/input_check/main.nf
+++ b/subworkflows/local/input_check/main.nf
@@ -40,7 +40,7 @@ workflow INPUT_CHECK {
     ch_spaceranger_combined = UNTAR_SPACERANGER_INPUT.out.untar
         .mix ( ch_spaceranger.dir.map { meta, dir -> [meta, file(dir)] } )
     // Create final meta map and check input existance
-    ch_spaceranger_input = ch_spaceranger_combined.view().map { meta, dir -> create_channel_spaceranger(meta, dir) }
+    ch_spaceranger_input = ch_spaceranger_combined.map { meta, dir -> create_channel_spaceranger(meta, dir) }
 
     // Downstream analysis: ----------------------------------------------------
 

--- a/subworkflows/local/input_check/main.nf
+++ b/subworkflows/local/input_check/main.nf
@@ -42,7 +42,7 @@ workflow INPUT_CHECK {
         .map { meta, dir -> meta + [fastq_dir: dir] }
 
     // Create final meta map and check input existance
-    ch_spaceranger_input = ch_spaceranger_combined.map { it -> create_channel_spaceranger(it) }
+    ch_spaceranger_input = ch_spaceranger_combined.view().map { it -> create_channel_spaceranger(it) }
 
     // Downstream analysis: ----------------------------------------------------
 
@@ -114,6 +114,7 @@ def check_downstream_dir(input, hd_bin_size) {
 // Function to get list of [ meta, [ fastq_dir, tissue_hires_image, slide, area ]]
 def create_channel_spaceranger(meta) {
     meta["id"] = meta.remove("sample")
+    println "meta: ${meta}"
     def slide = meta.remove("slide")
     def area = meta.remove("area")
     def fastq_dir = meta.remove("fastq_dir")

--- a/subworkflows/local/input_check/main.nf
+++ b/subworkflows/local/input_check/main.nf
@@ -112,7 +112,6 @@ def check_downstream_dir(input, hd_bin_size) {
 // Function to get list of [ meta, [ fastq_dir, tissue_hires_image, slide, area ]]
 def create_channel_spaceranger(meta, fastq_dir) {
     meta["id"] = meta.remove("sample")
-    println "meta: ${meta}"
     def slide = meta.remove("slide")
     def area = meta.remove("area")
     def fastq_files = fastq_dir.listFiles().findAll { file ->

--- a/tower.yml
+++ b/tower.yml
@@ -1,3 +1,13 @@
 reports:
-  samplesheet.csv:
-    display: "Auto-created samplesheet with collated metadata and FASTQ paths"
+  "multiqc_report.html":
+    display: "MultiQC report with comprehensive quality control metrics and summary statistics"
+  "**/reports/quality_controls.html":
+    display: "Quality control analysis report with filtering metrics and visualizations"
+  "**/reports/clustering.html":
+    display: "Clustering analysis report with dimensionality reduction and cell type identification"
+  "**/reports/spatially_variable_genes.html":
+    display: "Spatially variable genes analysis report with spatial autocorrelation results"
+  "**/fastqc/*.html":
+    display: "FastQC quality control reports for raw sequencing data"
+  "**/spaceranger/outs/web_summary.html":
+    display: "Space Ranger web summary with count statistics and quality metrics"


### PR DESCRIPTION
<!--
# nf-core/spatialvi pull request

Many thanks for contributing to nf-core/spatialvi!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/spatialvi/tree/main/.github/CONTRIBUTING.md)
-->

The current code has a big problem, in that [here](https://github.com/nf-core/spatialvi/blob/b20e4c7c05289af3da01209bb2da42a07a4e91b6/subworkflows/local/input_check/main.nf#L42) it puts a file object from UNTAR through a map, which flattens it into a string. A Path object representing an S3 bucket path like `s3://foo/bar` becomes just `/foo/bar`.

That causes problems when you get to [here](https://github.com/nf-core/spatialvi/blob/b20e4c7c05289af3da01209bb2da42a07a4e91b6/subworkflows/local/input_check/main.nf#L120), because the flattened path string (see above) looks like, but isn't, a local file path, so the FASTQ files are not found.

This PR addresses the issue by letting the Path object from UNTAR remain a path, and by making a path object (using `file`) from any actual directory paths in the sample sheet). Then we don't need the `file()` call in the Groovy function, and we can derive fastq files by querying the object.

Local paths DO flatten to something valid, which is why it worked in those contexts.

Also snuck a tower.yml in.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/spatialvi/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/spatialvi _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
