### PR TITLE
Update nf-schema plugin version to 2.7.2

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 10
+          max_shards: 15
 
       - name: debug
         run: |

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test-changes
       - runner=4cpu-linux-x64
-      - volume=80gb
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -65,6 +64,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - volume=40gb
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -66,6 +66,7 @@ jobs:
       - runner=4cpu-linux-x64
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
         profile: [conda, docker, singularity]

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -67,7 +67,6 @@ jobs:
       - runner=4cpu-linux-x64
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
         profile: [conda, docker, singularity]

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test-changes
       - runner=4cpu-linux-x64
+      - volume=40gb
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -50,7 +51,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 30
+          max_shards: 7
 
       - name: debug
         run: |

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test-changes
       - runner=4cpu-linux-x64
-      - volume=60gb
+      - volume=80gb
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test-changes
       - runner=4cpu-linux-x64
-      - volume=40gb
+      - volume=60gb
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 15
+          max_shards: 20
 
       - name: debug
         run: |

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 20
+          max_shards: 30
 
       - name: debug
         run: |

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 7
+          max_shards: 10
 
       - name: debug
         run: |

--- a/nextflow.config
+++ b/nextflow.config
@@ -348,7 +348,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
Bump nf-schema version to fix CLI parameter type casting with Nextflow v2 parser (default in Nextflow >= 26.04)

Note that an alternative workaround is to set the environment variable `NXF_SYNTAX_PARSER=1`

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/spatialvi/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/spatialvi _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


Current nf-core/spatialvi dev branch (https://github.com/nf-core/spatialvi/commit/d0fd35d9a985b30db9895c8b4b08f291a700f722) (tested in a codespace):
```
/workspaces/spatialvi -> nextflow run . -profile test,docker --outdir out --qc_min_counts 5   --qc_min_genes 3   --skip_downstream

 N E X T F L O W   ~  version 26.04.1

Launching `./main.nf` [admiring_rutherford] revision: dbc24d81d4

WARN: Unrecognized config option 'validation.defaultIgnoreParams'
WARN: Unrecognized config option 'validation.monochromeLogs'

------------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
  nf-core/spatialvi 1.0dev
------------------------------------------------------

Input/output options
  input                         : https://raw.githubusercontent.com/nf-core/test-datasets/spatialvi/testdata/human-brain-cancer-11-mm-capture-area-ffpe-2-standard_v2_ffpe_cytassist/samplesheet_spaceranger.csv
  outdir                        : out

Space Ranger options
  spaceranger_probeset          : https://raw.githubusercontent.com/nf-core/test-datasets/spatialvi/testdata/human-brain-cancer-11-mm-capture-area-ffpe-2-standard_v2_ffpe_cytassist/outs/probe_set.csv
  spaceranger_reference         : https://raw.githubusercontent.com/nf-core/test-datasets/spatialvi/testdata/homo_sapiens_chr22_reference.tar.gz

Filtering options
  qc_min_counts                 : 5
  qc_min_genes                  : 3
  qc_mito_threshold             : 20.0
  qc_ribo_threshold             : 0.0
  qc_hb_threshold               : 100.0

Principal component analysis options
  pca_use_highly_variable       : true

Clustering options
  cluster_resolution            : 1.0

Integration options
  integration_cluster_resolution: 1.0

Optional outputs
  skip_downstream               : true

Institutional config options
  config_profile_name           : Test profile
  config_profile_description    : Test pipeline functionality, including Space Ranger v2

Generic options
  trace_report_suffix           : 2026-05-21_15-23-12

Core Nextflow options
  runName                       : admiring_rutherford
  containerEngine               : docker
  container.REPORT              : community.wave.seqera.io/library/harmonypy_scanorama_gcc_gxx_pruned:95f731fde0b9ddef
  container.REPORT_INTEGRATED   : community.wave.seqera.io/library/harmonypy_scanorama_gcc_gxx_pruned:95f731fde0b9ddef
  container.MULTIQC             : docker.io/multiqc/multiqc:v1.29
  launchDir                     : /workspaces/spatialvi
  workDir                       : /workspaces/spatialvi/work
  projectDir                    : /workspaces/spatialvi
  userName                      : root
  profile                       : test,docker
  configFiles                   : /workspaces/spatialvi/nextflow.config

!! Only displaying parameters that differ from the pipeline defaults !!
------------------------------------------------------

* The nf-core framework
    https://doi.org/10.1038/s41587-020-0439-x

* Software dependencies
    https://github.com/nf-core/spatialvi/blob/master/CITATIONS.md

ERROR ~ Validation of pipeline parameters failed!

 -- Check '.nextflow.log' file for details
The following invalid input values have been detected:

* --qc_min_genes (3): Value is [string] but should be [integer]
* --qc_min_counts (5): Value is [string] but should be [integer]
* --skip_downstream (true): Value is [string] but should be [boolean]

 -- Check script 'subworkflows/nf-core/utils_nfschema_plugin/main.nf' at line: 68 or see '.nextflow.log' file for more details
 ```
 
 After bumping nf-schema to version 2.7.2 (this PR):
 
 ```
 /workspaces/spatialvi ->  nextflow run . -profile test,docker --outdir out --qc_min_counts 5   --qc_min_genes 3   --skip_downstream

 N E X T F L O W   ~  version 26.04.1

Launching `./main.nf` [pedantic_wescoff] revision: dbc24d81d4


------------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
  nf-core/spatialvi 1.0dev
------------------------------------------------------

Input/output options
  input                         : https://raw.githubusercontent.com/nf-core/test-datasets/spatialvi/testdata/human-brain-cancer-11-mm-capture-area-ffpe-2-standard_v2_ffpe_cytassist/samplesheet_spaceranger.csv
  outdir                        : out

Space Ranger options
  spaceranger_probeset          : https://raw.githubusercontent.com/nf-core/test-datasets/spatialvi/testdata/human-brain-cancer-11-mm-capture-area-ffpe-2-standard_v2_ffpe_cytassist/outs/probe_set.csv
  spaceranger_reference         : https://raw.githubusercontent.com/nf-core/test-datasets/spatialvi/testdata/homo_sapiens_chr22_reference.tar.gz

Filtering options
  qc_min_counts                 : 5
  qc_min_genes                  : 3
  qc_mito_threshold             : 20.0
  qc_ribo_threshold             : 0.0
  qc_hb_threshold               : 100.0

Principal component analysis options
  pca_use_highly_variable       : true

Clustering options
  cluster_resolution            : 1.0

Integration options
  integration_cluster_resolution: 1.0

Optional outputs
  skip_downstream               : true

Institutional config options
  config_profile_name           : Test profile
  config_profile_description    : Test pipeline functionality, including Space Ranger v2

Generic options
  trace_report_suffix           : 2026-05-21_15-59-20

Core Nextflow options
  runName                       : pedantic_wescoff
  containerEngine               : docker
  launchDir                     : /workspaces/spatialvi
  workDir                       : /workspaces/spatialvi/work
  projectDir                    : /workspaces/spatialvi
  userName                      : root
  profile                       : test,docker
  configFiles                   : /workspaces/spatialvi/nextflow.config

!! Only displaying parameters that differ from the pipeline defaults !!
------------------------------------------------------

* The nf-core framework
    https://doi.org/10.1038/s41587-020-0439-x

* Software dependencies
    https://github.com/nf-core/spatialvi/blob/master/CITATIONS.md

executor >  local (7)
[6f/57cf17] NFCORE_SPATIALVI:SPATIALVI:INPUT_CHECK:UNTAR_SPACERANGER_INPUT (fastq_dir.tar.gz)         [100%] 1 of 1 ✔
[-        ] NFCORE_SPATIALVI:SPATIALVI:INPUT_CHECK:UNTAR_DOWNSTREAM_INPUT                             -
[b5/e48a61] NFCORE_SPATIALVI:SPATIALVI:FASTQC (CytAssist_11mm_FFPE_Human_Glioblastoma_2)              [100%] 1 of 1 ✔
[ab/109694] NFC…ATIALVI:SPACERANGER:SPACERANGER_UNTAR_REFERENCE (homo_sapiens_chr22_reference.tar.gz) [100%] 1 of 1 ✔
[84/d9aab2] NFC…VI:SPATIALVI:SPACERANGER:SPACERANGER_COUNT (CytAssist_11mm_FFPE_Human_Glioblastoma_2) [100%] 1 of 1 ✔
[a3/ce59d7] NFCORE_SPATIALVI:SPATIALVI:SDATA_READ_VISIUM (CytAssist_11mm_FFPE_Human_Glioblastoma_2)   [100%] 1 of 1 ✔
[af/91e12e] NFCORE_SPATIALVI:SPATIALVI:SDATA_MERGE                                                    [100%] 1 of 1 ✔
[08/b50418] NFCORE_SPATIALVI:SPATIALVI:MULTIQC (spatialvi)                                            [100%] 1 of 1 ✔
-[nf-core/spatialvi] Pipeline completed successfully-
Completed at: 21-May-2026 16:09:24
Duration    : 10m 2s
CPU hours   : 0.6
Succeeded   : 7


 ```